### PR TITLE
feat: add context cancellation to BlockingLatch

### DIFF
--- a/internal/provider/connectors/amqp091/amqp091.go
+++ b/internal/provider/connectors/amqp091/amqp091.go
@@ -1221,7 +1221,7 @@ func (prov *amqp091provider) streamSubscribe(ctx context.Context, bd *BrokerDeta
 		return nil
 	}
 
-	latch := util.NewBlockingLatch(uint(source.GetPrefetchCount())) //nolint:gosec
+	latch := util.NewBlockingLatch(ctx, uint(source.GetPrefetchCount())) //nolint:gosec
 
 	consumerName, cErr := bd.getConsumerName(source)
 	if cErr != nil {
@@ -1259,7 +1259,9 @@ func (prov *amqp091provider) streamSubscribe(ctx context.Context, bd *BrokerDeta
 
 		// Increment the latch before we put the message on the channel
 		// Increment will wait for Decrement to be called if we have hit the ceiling
-		latch.Increment()
+		if err := latch.Increment(); err != nil {
+			return
+		}
 		messageChannel <- m
 		stm := streamMessage{Body: message.GetData(), Headers: m.GetHeaders()}
 		stm.Ack = func() {

--- a/internal/util/blocking_latch.go
+++ b/internal/util/blocking_latch.go
@@ -3,19 +3,24 @@
 
 package util
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 type BlockingLatch struct {
+	ctx    context.Context
 	count  uint
 	max    uint
 	lock   *sync.Mutex
 	notMax *sync.Cond
 }
 
-func NewBlockingLatch(m uint) *BlockingLatch {
+func NewBlockingLatch(ctx context.Context, m uint) *BlockingLatch {
 	lock := new(sync.Mutex)
 
 	bl := &BlockingLatch{
+		ctx:    ctx,
 		count:  0,
 		max:    m,
 		lock:   lock,
@@ -24,15 +29,22 @@ func NewBlockingLatch(m uint) *BlockingLatch {
 	return bl
 }
 
-func (bl *BlockingLatch) WaitForEmpty() {
+func (bl *BlockingLatch) WaitForEmpty() error {
+	stop := context.AfterFunc(bl.ctx, func() {
+		bl.notMax.Broadcast()
+	})
+	defer stop()
+
 	bl.lock.Lock()
 	defer bl.lock.Unlock()
 	for {
-		if bl.count > 0 {
-			bl.notMax.Wait()
-		} else {
-			return
+		if bl.count == 0 {
+			return nil
 		}
+		if err := bl.ctx.Err(); err != nil {
+			return err
+		}
+		bl.notMax.Wait()
 	}
 }
 
@@ -56,12 +68,6 @@ func (bl *BlockingLatch) GetMax() uint {
 	return bl.max
 }
 
-/*func (bl *BlockingLatch) inc() {
-	bl.lock.Lock()
-	bl.count++
-	bl.lock.Unlock()
-}*/
-
 func (bl *BlockingLatch) Decrement() {
 	bl.lock.Lock()
 	bl.count--
@@ -69,11 +75,22 @@ func (bl *BlockingLatch) Decrement() {
 	bl.lock.Unlock()
 }
 
-func (bl *BlockingLatch) Increment() {
+func (bl *BlockingLatch) Increment() error {
+	stop := context.AfterFunc(bl.ctx, func() {
+		bl.notMax.Broadcast()
+	})
+	defer stop()
+
 	bl.lock.Lock()
-	if bl.count >= bl.max {
+	defer bl.lock.Unlock()
+	for {
+		if bl.count < bl.max {
+			bl.count++
+			return nil
+		}
+		if err := bl.ctx.Err(); err != nil {
+			return err
+		}
 		bl.notMax.Wait()
 	}
-	bl.count++
-	bl.lock.Unlock()
 }

--- a/internal/util/blocking_latch_test.go
+++ b/internal/util/blocking_latch_test.go
@@ -4,26 +4,28 @@
 package util
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_BlockingLatch(t *testing.T) {
-	latch := NewBlockingLatch(2)
-	latch.Increment()
-	latch.Increment()
+	latch := NewBlockingLatch(context.Background(), 2)
+	require.NoError(t, latch.Increment())
+	require.NoError(t, latch.Increment())
 	assert.Equal(t, uint(2), latch.Count())
 	latch.Decrement()
 	assert.Equal(t, uint(1), latch.Count())
-	latch.Increment()
+	require.NoError(t, latch.Increment())
 	assert.Equal(t, uint(2), latch.Count())
 	go func(lt *BlockingLatch) {
 		time.Sleep(1000 * time.Millisecond)
 		lt.Decrement()
 	}(latch)
-	latch.Increment()
+	require.NoError(t, latch.Increment())
 	assert.Equal(t, uint(2), latch.Count())
 
 	go func(lt *BlockingLatch) {
@@ -32,6 +34,37 @@ func Test_BlockingLatch(t *testing.T) {
 		lt.Decrement()
 	}(latch)
 
-	latch.WaitForEmpty()
+	require.NoError(t, latch.WaitForEmpty())
 	assert.Equal(t, uint(0), latch.Count())
+}
+
+func Test_BlockingLatch_WaitForEmpty_Cancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	latch := NewBlockingLatch(ctx, 2)
+	require.NoError(t, latch.Increment())
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	err := latch.WaitForEmpty()
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, uint(1), latch.Count())
+}
+
+func Test_BlockingLatch_Increment_Cancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	latch := NewBlockingLatch(ctx, 1)
+	require.NoError(t, latch.Increment())
+	assert.Equal(t, uint(1), latch.Count())
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	err := latch.Increment()
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, uint(1), latch.Count())
 }


### PR DESCRIPTION
Resolve (#53)

- NewBlockingLatch now accepts a context.Context as the first argument, stored on the struct for use by blocking operations
- WaitForEmpty and Increment now return error; both use context.AfterFunc to broadcast on the cond var when the context is cancelled, causing blocked goroutines to wake and return ctx.Err()
- Updated amqp091 stream consumer to pass ctx to NewBlockingLatch and handle the Increment error return by exiting the message handler early