### PR TITLE
feat: improve connection failover speed and reliability

### DIFF
--- a/internal/provider/connectors/amqp091/amqp091.go
+++ b/internal/provider/connectors/amqp091/amqp091.go
@@ -452,7 +452,7 @@ func (prov *amqp091provider) Connect(ctx context.Context, cf *pb.ConnectionConfi
 	bd := BrokerDetails{
 		connectionConfig: cf,
 		ClientIdentifier: clientIdentifier,
-		ErrorChannel:     make(chan amqp091Error),
+		ErrorChannel:     make(chan amqp091Error, 1),
 		activeMessages:   activeMessages,
 		tlsSkipVerify:    tlsSkipVerify,
 		tlsConfig:        prov.tlsConfig,
@@ -747,13 +747,11 @@ func (prov *amqp091provider) declareQueue(source *pb.Source, bd *BrokerDetails, 
 }
 
 func (bd *BrokerDetails) getManagementClient() *http.Client {
-	client := &http.Client{}
-
 	if bd.tlsEnabled {
 		tr := &http.Transport{TLSClientConfig: bd.tlsConfig}
-		client = &http.Client{Transport: tr}
+		return &http.Client{Transport: tr, Timeout: 5 * time.Second}
 	}
-	return client
+	return &http.Client{Timeout: 5 * time.Second}
 }
 
 func (bd *BrokerDetails) doManagementRequest(method, urn string) ([]map[string]interface{}, error) {
@@ -1779,7 +1777,7 @@ func (prov *amqp091provider) SourceStats(ctx context.Context, source *pb.Source)
 }
 
 func sleepRandomReconnect() {
-	util.SleepRandom(500, provider.ReconnectDelay)
+	util.SleepRandom(100, provider.ReconnectDelay)
 }
 
 // connectionWatcher Called at the end of BrokerDetails.connect(), we monitor the bd.ErrorChannel and try to reconnect
@@ -1789,17 +1787,33 @@ func (bd *BrokerDetails) connectionWatcher() {
 		select {
 		case <-bd.shutdownChan:
 			return
-		case err, ok := <-bd.ErrorChannel:
+		case <-bd.ErrorChannel:
+			// Any receive on ErrorChannel means the AMQP connection has been
+			// closed.  The relay goroutine in NotifyClose only ever sends here
+			// when it receives from the underlying amqpErrors channel, which
+			// fires when the connection is torn down (either an AMQP close
+			// frame or a TCP-level close/RST).  Unconditionally reconnecting
+			// avoids a race where IsClosed() is still false at the time of
+			// the check even though the connection is genuinely gone.
 			bd.Lock()
-			if !ok || (err != (amqp091Error{}) && err.Code() != 0) {
-				bd.state = provider.DISCONNECTED
-				sleepRandomReconnect()
-				bd.Unlock()
-				// Ignore this error because we will reconnect in 30 seconds
-				bd.connect() //nolint:errcheck
-				continue
-			}
+			bd.state = provider.DISCONNECTED
 			bd.Unlock()
+			// Retry until we reconnect or the client explicitly disconnects.
+			// Without this loop, a single failed connect() would leave the
+			// watcher waiting for the 30-second fallback timer before trying
+			// again (because ErrorChannel is drained and no relay goroutine
+			// will send another notification until a new connection is made).
+			for !bd.clientDisconnect {
+				sleepRandomReconnect()
+				if ok, _ := bd.connect(); ok {
+					break
+				}
+				// connect() failed; reset state so the next attempt can proceed.
+				bd.Lock()
+				bd.state = provider.DISCONNECTED
+				bd.Unlock()
+			}
+			continue
 		case <-time.After(30 * time.Second):
 			// if we never get an error on the bd.ErrorChannel, try again after 30 seconds
 			// this is to help deal with race condition where we're not listening on the bd.ErrorChannel
@@ -1908,15 +1922,16 @@ func (bd *BrokerDetails) connect() (bool, error) {
 	}
 
 	bd.Connection = conn
-	bd.ErrorChannel = make(chan amqp091Error)
+	bd.ErrorChannel = make(chan amqp091Error, 1)
 	bd.ErrorChannel = bd.Connection.NotifyClose(bd.ErrorChannel) // this looks unneeded but it aids in unit testing
 	bd.state = provider.CONNECTED
 
 	util.Logger.Info(i18n.ClientConnected, bd.ClientIdentifier)
 
 	// pre-load the list of exchanges to help prevent declaration
-	// errors (PSGO-2001)
-	bd.loadExchanges()
+	// errors (PSGO-2001); done in the background so it does not delay
+	// reconnection from the caller's perspective.
+	go bd.loadExchanges()
 
 	return true, nil
 }

--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -18,5 +18,5 @@ const (
 	// CONNECTTIMEOUT Default timeout for waiting for connection in WaitForConnect()
 	CONNECTTIMEOUT = 15
 	// ReconnectDelay Maximum time to wait before a if we failed to connect
-	ReconnectDelay = 2000
+	ReconnectDelay = 500
 )

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	EnvMaxConnectRetries = "MAX_RECONNECT_RETRIES"
-	EnvMaxConnectDelay   = "MAX_RECONNECT_RETRIES"
+	EnvMaxConnectDelay   = "MAX_RECONNECT_DELAY"
 )
 
 var GetClientAddr = util.GetClientAddr

--- a/test/healthz/healthz.go
+++ b/test/healthz/healthz.go
@@ -15,6 +15,7 @@ import (
 	pb "github.com/sassoftware/arke/api"
 	"github.com/sassoftware/arke/internal/util"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -32,7 +33,7 @@ func main() {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-	conn, err := grpc.NewClient(address, grpc.WithInsecure(), grpc.WithKeepaliveParams(kacp)) //nolint:staticcheck
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithKeepaliveParams(kacp))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/tests/integration/failover_test.go
+++ b/tests/integration/failover_test.go
@@ -157,12 +157,35 @@ func (m *rabbitManagementClient) waitForConnections(minCount int, timeout time.D
 				return names, nil
 			}
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 	}
 	if lastErr != nil {
 		return nil, fmt.Errorf("timed out waiting for %d connection(s) after %s (management API %s – last error: %w) – check that ARKE_BROKER_HOSTNAME/ARKE_BROKER_ADMIN_PORT/ARKE_BROKER_USERNAME/ARKE_BROKER_PASSWORD are set correctly", minCount, timeout, m.baseURL, lastErr)
 	}
 	return nil, fmt.Errorf("timed out waiting for %d connection(s) after %s (last observed count: %d, management API %s) – the broker may not be connected or may be using a different vhost", minCount, timeout, lastCount, m.baseURL)
+}
+
+// waitForNoConnections polls until there are zero active connections or the deadline is reached.
+func (m *rabbitManagementClient) waitForNoConnections(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	var lastCount int
+	for time.Now().Before(deadline) {
+		names, err := m.listConnectionNames()
+		if err != nil {
+			lastErr = err
+		} else {
+			lastCount = len(names)
+			if len(names) == 0 {
+				return nil
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if lastErr != nil {
+		return fmt.Errorf("timed out waiting for 0 connections after %s (management API %s – last error: %w)", timeout, m.baseURL, lastErr)
+	}
+	return fmt.Errorf("timed out waiting for 0 connections after %s (last observed count: %d, management API %s)", timeout, lastCount, m.baseURL)
 }
 
 // ---------------------------------------------------------------------------
@@ -270,29 +293,43 @@ func TestConnectionWatcher_ReconnectsAfterBrokerClosesConnection(t *testing.T) {
 
 	// --- Step 3: forcefully close all broker connections -------------
 	t.Log("closing all RabbitMQ connections via management API")
+	closeStart := time.Now()
 	require.NoError(t, mgmt.closeAllConnections(), "management API must be reachable to run failover tests")
+	t.Logf("closeAllConnections returned after %s", time.Since(closeStart).Round(time.Millisecond))
 
-	// --- Step 4: wait for connectionWatcher to reconnect -------------
-	// connectionWatcher detects the non-zero error on ErrorChannel, sleeps
-	// a random backoff (500 ms – ReconnectDelay), then calls bd.connect().
-	// We allow up to 30 s.
-	t.Log("waiting for arke to reconnect (up to 30 s)...")
-	connsAfterReconnect, err := mgmt.waitForConnections(1, 30*time.Second)
-	require.NoError(t, err,
-		"arke should re-establish a connection to RabbitMQ within 30 s of the broker closing it")
-	t.Logf("arke reconnected; active connections: %v", connsAfterReconnect)
-
-	// --- Step 5: verify publish works on the recovered session -------
+	// --- Step 4: poll publish until arke has reconnected ------------
+	// Polling publishOne directly avoids any RabbitMQ stats-collection lag.
+	// The management API only reflects a new connection after its internal
+	// collection cycle (collect_statistics_interval), which can add 0.5-3 s
+	// of artificial delay even though arke itself reconnects in < 1 s.
+	//
+	// connectionWatcher wakes on bd.ErrorChannel unconditionally (any receive
+	// means the connection is gone), sleeps 100-500 ms (ReconnectDelay=500),
+	// then does a TCP+AMQP handshake (~10 ms on a local broker).
+	// Worst case reconnect latency: ~700 ms.  We allow 10 s for safety.
+	t.Log("polling publish to detect reconnect (up to 10 s)...")
+	reconnectStart := time.Now()
 	var publishErr error
-	for attempt := 1; attempt <= 5; attempt++ {
+	for time.Now().Before(reconnectStart.Add(10 * time.Second)) {
 		publishErr = session.publishOne(address)
 		if publishErr == nil {
 			break
 		}
-		t.Logf("publish attempt %d failed: %v – retrying", attempt, publishErr)
-		time.Sleep(2 * time.Second)
+		t.Logf("publish not yet recovered: %v – retrying in 200 ms", publishErr)
+		time.Sleep(200 * time.Millisecond)
 	}
-	assert.NoError(t, publishErr, "publish should succeed after arke reconnects to the broker")
+	t.Logf("reconnect detected after %s", time.Since(reconnectStart).Round(time.Millisecond))
+	require.NoError(t, publishErr,
+		"arke should re-establish a connection to RabbitMQ within 10 s of the broker closing it")
+
+	// --- Step 5: confirm a new AMQP connection is visible in RabbitMQ -
+	// This is a secondary check to verify connectionWatcher created a real
+	// new AMQP connection (not just that local publish state was satisfied).
+	// The management API may lag by up to collect_statistics_interval (500 ms),
+	// so we give it a generous window; it does not need to be fast.
+	connsAfterReconnect, err := mgmt.waitForConnections(1, 10*time.Second)
+	require.NoError(t, err, "management API should show a new RabbitMQ connection after reconnect")
+	t.Logf("active connections after reconnect: %v", connsAfterReconnect)
 }
 
 // TestConnectionWatcher_PublishRecovery verifies that after the broker
@@ -340,6 +377,104 @@ func TestConnectionWatcher_PublishRecovery(t *testing.T) {
 		time.Sleep(2 * time.Second)
 	}
 	assert.NoError(t, lastErr, "publish should recover within 30 s after broker-initiated disconnect")
+}
+
+// TestPublishStream_RecoveryDelay measures how long a streaming Publish RPC
+// takes to recover after the broker forcefully closes the connection.
+//
+// Unlike PublishOne (a stateless unary call retried by the caller), the
+// streaming Publish RPC keeps a single long-lived gRPC stream open.  When
+// the broker drops, the server-side Publish handler propagates the error to
+// the client on the stream, then calls WaitForConnect which polls until
+// connectionWatcher has re-established the AMQP connection.  Once reconnected
+// the outer Publish loop restarts and the same gRPC stream resumes — the
+// client never needs to re-open the stream.
+//
+// Sequence after closeAllConnections:
+//  1. connectionWatcher wakes (ErrorChannel notification), sleeps 100-500 ms,
+//     calls connect() → state=CONNECTED.
+//  2. prov.Publish (server-side) returns the broker error.
+//  3. Server outer loop is blocked at "errChan <- err" until the client sends
+//     the next message, which unblocks the server goroutine.
+//  4. Server goroutine sends an error response to the client and exits.
+//  5. Server calls WaitForConnect — which may return immediately if step 1
+//     already completed, or polls until it does.
+//  6. Server resumes the stream loop; client's next message succeeds.
+//
+// The test keeps sending every 200 ms so each stage unblocks promptly.
+// Total worst-case latency: reconnect backoff (500 ms) + WaitForConnect poll
+// (500 ms) ≈ 1 s.  We allow 15 s for safety.
+func TestPublishStream_RecoveryDelay(t *testing.T) {
+	mgmt := newRabbitManagementClient()
+
+	subjects := []string{"sas.test.failover.PSRD"}
+	address := &pb.Address{Name: "amq.topic", Subjects: subjects, Type: pb.Address_TOPIC}
+	msg := &pb.Message{Body: []byte("failover-stream-test"), Address: address}
+
+	// --- Step 1: open a persistent Publish stream --------------------
+	conn := connect()
+	defer conn.Close()
+	pc := pb.NewProducerClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	defer pc.Disconnect(ctx, &pb.Empty{})
+
+	connConfig := connectConfig(t.Name())
+	authResp, err := pc.Connect(ctx, connConfig)
+	require.NoError(t, err)
+	require.True(t, authResp.GetSuccess(), "arke broker Connect must succeed: %s", authResp.GetError().GetMessage())
+
+	stream, err := pc.Publish(ctx)
+	require.NoError(t, err, "Publish stream must open")
+	defer stream.CloseSend()
+
+	// sendAndRecv performs one Send/Recv round-trip on the stream.
+	sendAndRecv := func() error {
+		if sendErr := stream.Send(msg); sendErr != nil {
+			return fmt.Errorf("stream.Send: %w", sendErr)
+		}
+		r, recvErr := stream.Recv()
+		if recvErr != nil {
+			return fmt.Errorf("stream.Recv: %w", recvErr)
+		}
+		if !r.GetSuccess() {
+			return fmt.Errorf("broker error: %s", r.GetError().GetMessage())
+		}
+		return nil
+	}
+
+	// --- Step 2: warm-up ---------------------------------------------
+	require.NoError(t, sendAndRecv(), "baseline publish on stream must succeed")
+
+	// --- Step 3: drop all broker connections -------------------------
+	_, err = mgmt.waitForConnections(1, 10*time.Second)
+	require.NoError(t, err, "must see at least one connection before disruption")
+
+	t.Log("closing all RabbitMQ connections")
+	require.NoError(t, mgmt.closeAllConnections())
+
+	// --- Step 4: measure time to first successful publish on stream --
+	// Each sendAndRecv polls the stream.  The first call after the drop
+	// returns an error response: the server propagates the broker error and
+	// the client's send simultaneously unblocks the server goroutine that
+	// was waiting on errChan.  Subsequent calls buffer in gRPC while the
+	// server is inside WaitForConnect; as soon as WaitForConnect returns the
+	// server drains the buffer and responds with Success.
+	//
+	// We poll every 200 ms so each stage unblocks within one poll interval.
+	recoveryStart := time.Now()
+	var lastErr error
+	for time.Now().Before(recoveryStart.Add(15 * time.Second)) {
+		lastErr = sendAndRecv()
+		if lastErr == nil {
+			break
+		}
+		t.Logf("stream not yet recovered: %v – retrying in 200 ms", lastErr)
+		time.Sleep(200 * time.Millisecond)
+	}
+	elapsed := time.Since(recoveryStart).Round(time.Millisecond)
+	t.Logf("stream publish recovered after %s", elapsed)
+	require.NoError(t, lastErr, "streaming Publish should recover within 15 s of broker disconnect")
 }
 
 // TestConnectionWatcher_SubscribeErrorOnDisconnect verifies that an active

--- a/tests/integration/rabbitmq.conf
+++ b/tests/integration/rabbitmq.conf
@@ -10,3 +10,9 @@ ssl_options.verify = verify_none
 # default_user = guest
 # consumer_timeout = 60000
 message_interceptors.incoming.set_header_timestamp.overwrite = true
+# Reduce the management stats collection interval so that new connections
+# appear in /api/connections quickly.  RabbitMQ flushes connection state to
+# its stats DB on this cycle, so a freshly reconnected client may not be
+# visible until the next flush.  500 ms gives worst-case ~500 ms API lag
+# (down from the 5 s default), keeping failover-test detection well under 2 s.
+collect_statistics_interval = 500


### PR DESCRIPTION
Resolve(#44)

- Buffer ErrorChannel (cap 1) to prevent the relay goroutine from blocking when connectionWatcher has not yet called receive
- Update connectionWatcher to reconnect unconditionally on any ErrorChannel receive, retrying in a loop until successful or the client disconnects; removes the IsClosed() race condition
- Reduce reconnect backoff: min sleep 500 -> 100 ms, changed ReconnectDelay constant from 2000 to 500 ms
- Run loadExchanges in a background goroutine so reconnect is not delayed by the management-API exchange list fetch
- Add 5 s timeout to the HTTP management client

tests/integration:
- Add TestPublishStream_RecoveryDelay to measure streaming Publish RPC recovery time after a broker-initiated disconnect

test/healthz:
- Replace deprecated grpc.WithInsecure() with grpc.WithTransportCredentials(insecure.NewCredentials())