### PR TITLE
fix(util): close race in ConcurrentMap.Length, nil-resource in tracin…

### DIFF
--- a/internal/util/concurrentMap.go
+++ b/internal/util/concurrentMap.go
@@ -57,5 +57,7 @@ func (cm *ConcurrentMap) GetList() []string {
 
 // Length Return the length of the map
 func (cm *ConcurrentMap) Length() int {
+	cm.RLock()
+	defer cm.RUnlock()
 	return len(cm.items)
 }

--- a/internal/util/concurrentMap_test.go
+++ b/internal/util/concurrentMap_test.go
@@ -4,6 +4,8 @@
 package util
 
 import (
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,4 +59,36 @@ func TestConcurrentMapGetList(t *testing.T) {
 	cMap.Add("testItem", testItem)
 	cMap.Add("testItem2", testItem)
 	assert.Len(t, cMap.GetList(), 2)
+}
+
+// TestConcurrentMap_LengthIsRaceFree exercises Length() concurrently with
+// Add/Delete under -race. Without the read-lock in Length(), the race detector
+// flags the unsynchronized len(cm.items) read against the locked writes.
+func TestConcurrentMap_LengthIsRaceFree(t *testing.T) {
+	cMap := NewConcurrentMap()
+	const workers = 8
+	const iters = 500
+
+	var wg sync.WaitGroup
+	wg.Add(workers * 2)
+
+	for w := 0; w < workers; w++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				key := strconv.Itoa(id*iters + i)
+				cMap.Add(key, i)
+				cMap.Delete(key)
+			}
+		}(w)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				_ = cMap.Length()
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, 0, cMap.Length())
 }

--- a/internal/util/tracing/tracing.go
+++ b/internal/util/tracing/tracing.go
@@ -24,6 +24,7 @@ import (
 )
 
 var initResourcesOnce sync.Once
+var tracingResource *sdkresource.Resource
 var tracingEnabled bool
 
 const (
@@ -61,9 +62,8 @@ func getTelemetryEnabled() bool {
 }
 
 func initResource() *sdkresource.Resource {
-	var resource *sdkresource.Resource
 	initResourcesOnce.Do(func() {
-		resource, _ = sdkresource.New(
+		tracingResource, _ = sdkresource.New(
 			context.Background(),
 			sdkresource.WithTelemetrySDK(),
 			sdkresource.WithOS(),
@@ -76,7 +76,7 @@ func initResource() *sdkresource.Resource {
 			),
 		)
 	})
-	return resource
+	return tracingResource
 }
 
 func Enabled() bool {

--- a/internal/util/tracing/tracing_test.go
+++ b/internal/util/tracing/tracing_test.go
@@ -67,6 +67,18 @@ func Test_getTelemetryCollectorAddress_set(t *testing.T) {
 	assert.Equal(t, "localhost:12345", addr)
 }
 
+// Test_initResource_returnsSamePointer guards against a regression where
+// initResource declared the *sdkresource.Resource locally; the sync.Once body
+// would only run on the first call, leaving subsequent calls to return a
+// freshly-declared nil. With the package-level tracingResource, every call
+// must return the same non-nil pointer.
+func Test_initResource_returnsSamePointer(t *testing.T) {
+	r1 := initResource()
+	r2 := initResource()
+	assert.NotNil(t, r1)
+	assert.Same(t, r1, r2)
+}
+
 func Test_SpanFromHeaders(t *testing.T) {
 	os.Setenv(EnvOtelSdkDisabled, "false")
 	defer os.Setenv(EnvOtelSdkDisabled, "true")

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -97,6 +97,10 @@ func NewTimestampPB() *timestamppb.Timestamp {
 }
 
 func SleepRandom(sleepMin int, sleepMax int) {
+	if sleepMax <= sleepMin {
+		time.Sleep(time.Duration(sleepMin) * time.Millisecond)
+		return
+	}
 	rn := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
 
 	splay := time.Duration(rn.Intn(sleepMax-sleepMin)+sleepMin) * time.Millisecond

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -126,6 +126,23 @@ func Test_GetConfig(t *testing.T) {
 	assert.Equal(t, "foo", strVal)
 }
 
+func Test_SleepRandom(t *testing.T) {
+	// Normal range: should sleep at least sleepMin ms.
+	start := time.Now()
+	SleepRandom(5, 15)
+	assert.GreaterOrEqual(t, time.Since(start), 5*time.Millisecond)
+
+	// sleepMax == sleepMin: previously panicked in rand.Intn(0); now sleeps sleepMin.
+	start = time.Now()
+	SleepRandom(10, 10)
+	assert.GreaterOrEqual(t, time.Since(start), 10*time.Millisecond)
+
+	// sleepMax < sleepMin: previously panicked in rand.Intn(<0); now sleeps sleepMin.
+	start = time.Now()
+	SleepRandom(10, 5)
+	assert.GreaterOrEqual(t, time.Since(start), 10*time.Millisecond)
+}
+
 func TestServceNameFromClientAddr(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Fixes #89

- ConcurrentMap.Length() now takes the read lock; len() on the map was unsynchronized while Add/Delete mutate under the write lock.
- tracing.initResource() moves the resource pointer to package scope so calls after the first don't return a freshly-declared nil. The sync.Once intentionally only runs the constructor once, but the previous local variable was re-declared on every call.
- util.SleepRandom() guards against sleepMax <= sleepMin, where the prior call into rand.Intn would panic (n must be > 0).