### PR TITLE
fix(amqp091): close race on BrokerDetails.clientDisconnect

### DIFF
--- a/internal/provider/connectors/amqp091/amqp091.go
+++ b/internal/provider/connectors/amqp091/amqp091.go
@@ -111,6 +111,10 @@ type BrokerDetails struct {
 	tlsConfig        *tls.Config
 	tlsEnabled       bool
 	shutdownChan     chan bool
+	// watcherWG tracks the connectionWatcher goroutine so callers (notably
+	// tests) can wait for it to exit after a Disconnect, rather than letting
+	// it outlive the connection.
+	watcherWG sync.WaitGroup
 }
 
 func init() {
@@ -511,7 +515,11 @@ func (prov *amqp091provider) Connect(ctx context.Context, cf *pb.ConnectionConfi
 		return &pb.Error{Message: bdErr.Error()}
 	}
 	prov.connections.Add(bd.ClientIdentifier, &bd)
-	go bd.connectionWatcher()
+	bd.watcherWG.Add(1)
+	go func() {
+		defer bd.watcherWG.Done()
+		bd.connectionWatcher()
+	}()
 
 	return nil
 }

--- a/internal/provider/connectors/amqp091/amqp091.go
+++ b/internal/provider/connectors/amqp091/amqp091.go
@@ -106,7 +106,7 @@ type BrokerDetails struct {
 	ActiveStreams    int64
 	consumed         int64
 	produced         int64
-	clientDisconnect bool
+	clientDisconnect atomic.Bool
 	lastPubSubEvent  time.Time
 	tlsConfig        *tls.Config
 	tlsEnabled       bool
@@ -463,7 +463,6 @@ func (prov *amqp091provider) Connect(ctx context.Context, cf *pb.ConnectionConfi
 		produced:         0,
 		consumed:         0,
 		ActiveStreams:    0,
-		clientDisconnect: false,
 		lastPubSubEvent:  time.Now(),
 		shutdownChan:     make(chan bool, 1),
 		pubChannelCtx:    pubChCtx,
@@ -1338,7 +1337,7 @@ func (prov *amqp091provider) disconnectClientByIdentifier(clientIdentifier strin
 	}()
 
 	bd.pubChannelCancel()
-	bd.clientDisconnect = true
+	bd.clientDisconnect.Store(true)
 	util.Logger.Info(i18n.ClientDisconnect, bd.ClientIdentifier)
 	bd.shutdownChan <- true // shut down the connectionWatcher
 	// close the client if it is still connected
@@ -1798,7 +1797,7 @@ func sleepRandomReconnect() {
 // connectionWatcher Called at the end of BrokerDetails.connect(), we monitor the bd.ErrorChannel and try to reconnect
 // if we get an error on the channel. Receiving nil on the channel means we've closed because of the client
 func (bd *BrokerDetails) connectionWatcher() {
-	for !bd.clientDisconnect {
+	for !bd.clientDisconnect.Load() {
 		select {
 		case <-bd.shutdownChan:
 			return
@@ -1816,7 +1815,7 @@ func (bd *BrokerDetails) connectionWatcher() {
 			// watcher waiting for the 30-second fallback timer before trying
 			// again (because ErrorChannel is drained and no relay goroutine
 			// will send another notification until a new connection is made).
-			for !bd.clientDisconnect {
+			for !bd.clientDisconnect.Load() {
 				sleepRandomReconnect()
 				if ok, _ := bd.connect(); ok {
 					break
@@ -1858,7 +1857,7 @@ func (bd *BrokerDetails) waitWhileConnecting() uint32 {
 }
 
 func (bd *BrokerDetails) connect() (bool, error) {
-	if bd.clientDisconnect {
+	if bd.clientDisconnect.Load() {
 		return false, nil
 	}
 

--- a/internal/provider/connectors/amqp091/amqp091_test.go
+++ b/internal/provider/connectors/amqp091/amqp091_test.go
@@ -2355,7 +2355,7 @@ func Test_SetupDeadLetter_no_BD(t *testing.T) {
 
 func Test_connect_clientDisconnect(t *testing.T) {
 	bd := BrokerDetails{}
-	bd.clientDisconnect = true
+	bd.clientDisconnect.Store(true)
 	ok, err := bd.connect()
 	assert.False(t, ok)
 	assert.Nil(t, err)
@@ -2364,7 +2364,6 @@ func Test_connect_clientDisconnect(t *testing.T) {
 func Test_connect_connecting_connected(t *testing.T) {
 	bd := BrokerDetails{}
 	bd.state.Store(provider.CONNECTING)
-	bd.clientDisconnect = false
 	go func() {
 		time.Sleep(1 * time.Second)
 		bd.state.Store(provider.CONNECTED)
@@ -2377,7 +2376,6 @@ func Test_connect_connecting_connected(t *testing.T) {
 func Test_connect_connecting_closed(t *testing.T) {
 	bd := BrokerDetails{}
 	bd.state.Store(provider.CONNECTING)
-	bd.clientDisconnect = false
 	go func() {
 		time.Sleep(1 * time.Second)
 		bd.state.Store(provider.CLOSED)
@@ -2390,7 +2388,6 @@ func Test_connect_connecting_closed(t *testing.T) {
 func Test_connect_connecting_disconnected(t *testing.T) {
 	bd := BrokerDetails{}
 	bd.state.Store(provider.CONNECTING)
-	bd.clientDisconnect = false
 
 	msrv := mockManagementRequestServer()
 	defer msrv.Close()

--- a/internal/provider/connectors/amqp091/amqp091_test.go
+++ b/internal/provider/connectors/amqp091/amqp091_test.go
@@ -36,6 +36,35 @@ const testContentTypeJSON = "application/json"
 const testContentEncodingText = "text"
 const testXMatchAny = "any"
 
+// stopWatcher disconnects the client identified by ctx and blocks until its
+// connectionWatcher goroutine has fully exited. Tests that call prov.Connect
+// should defer this so the watcher cannot outlive the test and either race the
+// package-level NewAmqpConn091 swap (read in connect()) or panic calling
+// IsClosed() on a stale mock from its 30s fallback branch. It is a no-op if the
+// connection was already disconnected.
+func stopWatcher(ctx context.Context, p provider.Provider) {
+	prov, ok := p.(*amqp091provider)
+	if !ok {
+		return
+	}
+	id, err := GetClientIdentifier(ctx)
+	if err != nil {
+		return
+	}
+	bdu, ok := prov.connections.Get(id)
+	if !ok {
+		return
+	}
+	bd := bdu.(*BrokerDetails)
+	// Skip the disconnect if the test already triggered one: a second
+	// disconnectClientByIdentifier would block on the buffered shutdownChan.
+	// The watcher still stops on the existing clientDisconnect, so just wait.
+	if !bd.clientDisconnect.Load() {
+		prov.disconnectClientByIdentifier(id)
+	}
+	bd.watcherWG.Wait()
+}
+
 func init() {
 	// Register the MockProvider with the Provider factory.
 
@@ -173,6 +202,7 @@ func TestConnect(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 
 	assert.Nil(t, err)
 
@@ -203,6 +233,7 @@ func TestConnect_Error(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 
 	assert.NotNil(t, err)
 
@@ -225,6 +256,7 @@ func Test_Connect_NoClient(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.GetMessage(), "noclient")
@@ -257,6 +289,7 @@ func TestConnect_TLS_SkipVerify(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	cc.Tls = true
 	err := prov.Connect(ctx, cc, true)
+	defer stopWatcher(ctx, prov)
 
 	assert.Nil(t, err)
 
@@ -291,6 +324,7 @@ func TestConnect_TLS_WithCert(t *testing.T) {
 	cc.Tls = true
 	cc.CaCertificate = []byte("asdf")
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 
 	assert.Nil(t, err)
 
@@ -323,6 +357,7 @@ func TestConnect_Stats(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	stats := prov.Stats()
@@ -358,6 +393,7 @@ func setupProviderWithSimpleConn(t *testing.T) (provider.Provider, context.Conte
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	cleanup := func() {
@@ -440,6 +476,7 @@ func Test_Ack_AckErr(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -504,6 +541,7 @@ func Test_Retry_NoMsg(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	msg := pb.Message{}
 	err = prov.Retry(ctx, &pb.Source{}, msg.GetUuid(), 10)
@@ -537,6 +575,7 @@ func Test_DeadLetter_NoMsg(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	msg := pb.Message{}
 	err = prov.DeadLetter(ctx, &pb.Source{}, msg.GetUuid())
@@ -607,6 +646,7 @@ func Test_Ack(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -698,6 +738,7 @@ func Test_Nack(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -787,6 +828,7 @@ func Test_Nack_NackErr(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -881,6 +923,7 @@ func Test_Retry(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	src := &pb.Source{Name: "queue", Address: &pb.Address{Name: "address"}}
@@ -968,6 +1011,7 @@ func Test_RetryFailure(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	src := &pb.Source{Name: "queue", Address: &pb.Address{Name: "address"}}
@@ -1071,6 +1115,7 @@ func Test_RetryFailure_DeclareErrorsStillSuccess(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	opts := make(map[string]string)
@@ -1258,6 +1303,7 @@ func Test_DLQ(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -1497,6 +1543,7 @@ func Test_Subscribe_Options(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -1607,6 +1654,7 @@ func Test_Subscribe_NoSubjectsNoFilters(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -1683,6 +1731,7 @@ func Test_Subscribe_UnsupportedOptions(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	src := &pb.Source{Address: &pb.Address{Name: "addressname"}, Options: options}
@@ -1724,6 +1773,7 @@ func Test_Disconnect(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	prov.Disconnect(ctx)
 
@@ -1771,6 +1821,7 @@ func Test_WaitForConnect(t *testing.T) {
 
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	errs <- newAmqp091Error("chanerr", 1) // simulate an error
 	time.Sleep(500 * time.Millisecond)
@@ -1829,6 +1880,7 @@ func Test_Publish(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	go func() {
@@ -1890,6 +1942,7 @@ func Test_Publish_Error(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	go func() {
@@ -1957,6 +2010,7 @@ func Test_PublishOne(t *testing.T) {
 
 		suberr := prov.PublishOne(ctx, msg)
 
+		stopWatcher(ctx, prov)
 		NewAmqpConn091 = oldNewAmqpConn091
 
 		assert.Nil(t, suberr)
@@ -2007,6 +2061,7 @@ func Test_PublishOneFailed(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -2052,6 +2107,7 @@ func Test_PublishOneFailedNewChannel(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -2093,6 +2149,7 @@ func Test_PublishOneFailedConnClosed(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -2172,6 +2229,7 @@ func Test_Publish_ErrorDeclareExchange(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	go func() {
@@ -2277,6 +2335,7 @@ func Test_ClientExists(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	exists := prov.ClientExists("1234")
@@ -2309,6 +2368,7 @@ func Test_ClientExists_false(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	exists := prov.ClientExists("4321")
@@ -2663,6 +2723,7 @@ func Test_Subscribe_Queue_DeclareOnly(t *testing.T) {
 
 				err := prov.Connect(ctx, cc, false)
 				assert.Nil(t, err)
+				defer stopWatcher(ctx, prov)
 
 				mc := make(chan *pb.Message)
 				defer close(mc)
@@ -2975,6 +3036,7 @@ func Test_Publish_ContextCancellation_ExitsPromptly(t *testing.T) {
 	defer cancel()
 	cc := &pb.ConnectionConfiguration{}
 	assert.Nil(t, prov.Connect(ctx, cc, false))
+	defer stopWatcher(ctx, prov)
 
 	// messageChannel is never closed and never has messages.  The only exit
 	// from the Publish select loop is ctx.Done() (post-fix) or an AMQP error
@@ -3040,6 +3102,7 @@ func Test_Publish_NotifyCloseChannelsAreBuffered(t *testing.T) {
 	defer cancel()
 	cc := &pb.ConnectionConfiguration{}
 	assert.Nil(t, prov.Connect(ctx, cc, false))
+	defer stopWatcher(ctx, prov)
 
 	messageChannel := make(chan *pb.Message)
 	errChan := make(chan *pb.Error, 1)
@@ -3143,6 +3206,7 @@ func Test_QueueSubscribe_NotifyCloseChannelsAreBuffered(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	assert.Nil(t, prov.Connect(ctx, cc, false))
+	defer stopWatcher(ctx, prov)
 
 	src := &pb.Source{
 		Name:    "queue",

--- a/internal/provider/connectors/amqp091/amqp091_test.go
+++ b/internal/provider/connectors/amqp091/amqp091_test.go
@@ -2310,69 +2310,49 @@ func Test_SetDelivery(t *testing.T) {
 }
 
 func Test_ClientExists(t *testing.T) {
-	prov := NewAMQP091Provider()
-
-	oldGetClientIdentifier := GetClientIdentifier
-	GetClientIdentifier = func(context.Context) (string, error) {
-		return "1234", nil
+	tests := []struct {
+		name     string
+		clientID string
+		want     bool
+	}{
+		{"exists", "1234", true},
+		{"not exists", "4321", false},
 	}
 
-	amock := &amqpConnectionMock{}
-	amock.On("Connect").Return(nil)
-	errs := make(chan amqp091Error)
-	amock.On("NotifyClose").Return(errs)
-	oldNewAmqpConn091 := NewAmqpConn091
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prov := NewAMQP091Provider()
 
-	NewAmqpConn091 = func(string, string, *tls.Config) amqp091ConnectionShim {
-		return amock
+			oldGetClientIdentifier := GetClientIdentifier
+			GetClientIdentifier = func(context.Context) (string, error) {
+				return "1234", nil
+			}
+
+			amock := &amqpConnectionMock{}
+			amock.On("Connect").Return(nil)
+			errs := make(chan amqp091Error)
+			amock.On("NotifyClose").Return(errs)
+			oldNewAmqpConn091 := NewAmqpConn091
+
+			NewAmqpConn091 = func(string, string, *tls.Config) amqp091ConnectionShim {
+				return amock
+			}
+
+			defer func() {
+				GetClientIdentifier = oldGetClientIdentifier
+				NewAmqpConn091 = oldNewAmqpConn091
+			}()
+
+			ctx := context.Background()
+			cc := &pb.ConnectionConfiguration{}
+			err := prov.Connect(ctx, cc, false)
+			defer stopWatcher(ctx, prov)
+			assert.Nil(t, err)
+
+			exists := prov.ClientExists(tt.clientID)
+			assert.Equal(t, tt.want, exists)
+		})
 	}
-
-	defer func() {
-		GetClientIdentifier = oldGetClientIdentifier
-		NewAmqpConn091 = oldNewAmqpConn091
-	}()
-
-	ctx := context.Background()
-	cc := &pb.ConnectionConfiguration{}
-	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(ctx, prov)
-	assert.Nil(t, err)
-
-	exists := prov.ClientExists("1234")
-	assert.True(t, exists)
-}
-
-func Test_ClientExists_false(t *testing.T) {
-	prov := NewAMQP091Provider()
-
-	oldGetClientIdentifier := GetClientIdentifier
-	GetClientIdentifier = func(context.Context) (string, error) {
-		return "1234", nil
-	}
-
-	amock := &amqpConnectionMock{}
-	amock.On("Connect").Return(nil)
-	errs := make(chan amqp091Error)
-	amock.On("NotifyClose").Return(errs)
-	oldNewAmqpConn091 := NewAmqpConn091
-
-	NewAmqpConn091 = func(string, string, *tls.Config) amqp091ConnectionShim {
-		return amock
-	}
-
-	defer func() {
-		GetClientIdentifier = oldGetClientIdentifier
-		NewAmqpConn091 = oldNewAmqpConn091
-	}()
-
-	ctx := context.Background()
-	cc := &pb.ConnectionConfiguration{}
-	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(ctx, prov)
-	assert.Nil(t, err)
-
-	exists := prov.ClientExists("4321")
-	assert.False(t, exists)
 }
 
 func Test_getBrokerDetails_err(t *testing.T) {

--- a/internal/provider/connectors/amqp091/stream_test.go
+++ b/internal/provider/connectors/amqp091/stream_test.go
@@ -260,6 +260,7 @@ func Test_PublishStream(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	go func() {
@@ -332,6 +333,7 @@ func Test_PublishStreamWithConfirm(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	go func() {
@@ -391,6 +393,7 @@ func Test_PublishStreamFailed(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -443,6 +446,7 @@ func Test_PublishStreamFailedConn(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -496,6 +500,7 @@ func Test_PublishStreamNotConn(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -561,6 +566,7 @@ func Test_SubscribeStream(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -637,6 +643,7 @@ func Test_SubscribeStreamBadOpt(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	ctx, cancel := context.WithCancel(context.Background())
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -793,6 +800,7 @@ func Test_SubscribeStreamAutoDeleteOrExclusive(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	ctx, cancel := context.WithCancel(context.Background())
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -865,6 +873,7 @@ func Test_SubscribeStreamInvalidTTL(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	ctx, cancel := context.WithCancel(context.Background())
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -927,6 +936,7 @@ func Test_SubscribeStreamFailedConn(t *testing.T) {
 
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -989,6 +999,7 @@ func Test_SubscribeStreamNotConn(t *testing.T) {
 
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -1053,6 +1064,7 @@ func Test_SubscribeStreamFailedDeclare(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -1124,6 +1136,7 @@ func Test_StreamRetry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -1208,6 +1221,7 @@ func Test_Subscribe_Stream_DeclareOnly(t *testing.T) {
 				cc := &pb.ConnectionConfiguration{}
 				err := prov.Connect(ctx, cc, false)
 				assert.Nil(t, err)
+				defer stopWatcher(ctx, prov)
 
 				mc := make(chan *pb.Message)
 				defer close(mc)


### PR DESCRIPTION
Fixes #101

Switch `BrokerDetails.clientDisconnect` from `bool` to `atomic.Bool` so the `connectionWatcher` goroutine and the `Disconnect` caller can no longer race, mirroring the pattern already used in `streamshim.go`.
