### PR TITLE
test(amqp091): join connectionWatcher goroutines in test teardown

### DIFF
--- a/internal/provider/connectors/amqp091/amqp091.go
+++ b/internal/provider/connectors/amqp091/amqp091.go
@@ -111,6 +111,10 @@ type BrokerDetails struct {
 	tlsConfig        *tls.Config
 	tlsEnabled       bool
 	shutdownChan     chan bool
+	// watcherWG tracks the connectionWatcher goroutine so callers (notably
+	// tests) can wait for it to exit after a Disconnect, rather than letting
+	// it outlive the connection.
+	watcherWG sync.WaitGroup
 }
 
 func init() {
@@ -507,7 +511,11 @@ func (prov *amqp091provider) Connect(ctx context.Context, cf *pb.ConnectionConfi
 		return &pb.Error{Message: bdErr.Error()}
 	}
 	prov.connections.Add(bd.ClientIdentifier, &bd)
-	go bd.connectionWatcher()
+	bd.watcherWG.Add(1)
+	go func() {
+		defer bd.watcherWG.Done()
+		bd.connectionWatcher()
+	}()
 
 	return nil
 }

--- a/internal/provider/connectors/amqp091/amqp091_test.go
+++ b/internal/provider/connectors/amqp091/amqp091_test.go
@@ -36,6 +36,35 @@ const testContentTypeJSON = "application/json"
 const testContentEncodingText = "text"
 const testXMatchAny = "any"
 
+// stopWatcher disconnects the client identified by ctx and blocks until its
+// connectionWatcher goroutine has fully exited. Tests that call prov.Connect
+// should defer this so the watcher cannot outlive the test and either race the
+// package-level NewAmqpConn091 swap (read in connect()) or panic calling
+// IsClosed() on a stale mock from its 30s fallback branch. It is a no-op if the
+// connection was already disconnected.
+func stopWatcher(p provider.Provider, ctx context.Context) {
+	prov, ok := p.(*amqp091provider)
+	if !ok {
+		return
+	}
+	id, err := GetClientIdentifier(ctx)
+	if err != nil {
+		return
+	}
+	bdu, ok := prov.connections.Get(id)
+	if !ok {
+		return
+	}
+	bd := bdu.(*BrokerDetails)
+	// Skip the disconnect if the test already triggered one: a second
+	// disconnectClientByIdentifier would block on the buffered shutdownChan.
+	// The watcher still stops on the existing clientDisconnect, so just wait.
+	if !bd.clientDisconnect.Load() {
+		prov.disconnectClientByIdentifier(id)
+	}
+	bd.watcherWG.Wait()
+}
+
 func init() {
 	// Register the MockProvider with the Provider factory.
 
@@ -173,6 +202,7 @@ func TestConnect(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 
 	assert.Nil(t, err)
 
@@ -203,6 +233,7 @@ func TestConnect_Error(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 
 	assert.NotNil(t, err)
 
@@ -225,6 +256,7 @@ func Test_Connect_NoClient(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.GetMessage(), "noclient")
@@ -257,6 +289,7 @@ func TestConnect_TLS_SkipVerify(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	cc.Tls = true
 	err := prov.Connect(ctx, cc, true)
+	defer stopWatcher(prov, ctx)
 
 	assert.Nil(t, err)
 
@@ -291,6 +324,7 @@ func TestConnect_TLS_WithCert(t *testing.T) {
 	cc.Tls = true
 	cc.CaCertificate = []byte("asdf")
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 
 	assert.Nil(t, err)
 
@@ -323,6 +357,7 @@ func TestConnect_Stats(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	stats := prov.Stats()
@@ -358,6 +393,7 @@ func setupProviderWithSimpleConn(t *testing.T) (provider.Provider, context.Conte
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	cleanup := func() {
@@ -440,6 +476,7 @@ func Test_Ack_AckErr(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -504,6 +541,7 @@ func Test_Retry_NoMsg(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 	msg := pb.Message{}
 	err = prov.Retry(ctx, &pb.Source{}, msg.GetUuid(), 10)
@@ -537,6 +575,7 @@ func Test_DeadLetter_NoMsg(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 	msg := pb.Message{}
 	err = prov.DeadLetter(ctx, &pb.Source{}, msg.GetUuid())
@@ -607,6 +646,7 @@ func Test_Ack(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -698,6 +738,7 @@ func Test_Nack(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -787,6 +828,7 @@ func Test_Nack_NackErr(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -882,6 +924,7 @@ func Test_Retry(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	src := &pb.Source{Name: "queue", Address: &pb.Address{Name: "address"}}
@@ -969,6 +1012,7 @@ func Test_RetryFailure(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	src := &pb.Source{Name: "queue", Address: &pb.Address{Name: "address"}}
@@ -1072,6 +1116,7 @@ func Test_RetryFailure_DeclareErrorsStillSuccess(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	opts := make(map[string]string)
@@ -1251,6 +1296,7 @@ func Test_DLQ(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -1490,6 +1536,7 @@ func Test_Subscribe_Options(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -1600,6 +1647,7 @@ func Test_Subscribe_NoSubjectsNoFilters(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -1676,6 +1724,7 @@ func Test_Subscribe_UnsupportedOptions(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	src := &pb.Source{Address: &pb.Address{Name: "addressname"}, Options: options}
@@ -1717,6 +1766,7 @@ func Test_Disconnect(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 	prov.Disconnect(ctx)
 
@@ -1764,6 +1814,7 @@ func Test_WaitForConnect(t *testing.T) {
 
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 	errs <- newAmqp091Error("chanerr", 1) // simulate an error
 	time.Sleep(500 * time.Millisecond)
@@ -1822,6 +1873,7 @@ func Test_Publish(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	go func() {
@@ -1883,6 +1935,7 @@ func Test_Publish_Error(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	go func() {
@@ -1950,6 +2003,7 @@ func Test_PublishOne(t *testing.T) {
 
 		suberr := prov.PublishOne(ctx, msg)
 
+		stopWatcher(prov, ctx)
 		NewAmqpConn091 = oldNewAmqpConn091
 
 		assert.Nil(t, suberr)
@@ -2000,6 +2054,7 @@ func Test_PublishOneFailed(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -2045,6 +2100,7 @@ func Test_PublishOneFailedNewChannel(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -2086,6 +2142,7 @@ func Test_PublishOneFailedConnClosed(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -2165,6 +2222,7 @@ func Test_Publish_ErrorDeclareExchange(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	go func() {
@@ -2270,6 +2328,7 @@ func Test_ClientExists(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	exists := prov.ClientExists("1234")
@@ -2302,6 +2361,7 @@ func Test_ClientExists_false(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	exists := prov.ClientExists("4321")
@@ -2656,6 +2716,7 @@ func Test_Subscribe_Queue_DeclareOnly(t *testing.T) {
 
 				err := prov.Connect(ctx, cc, false)
 				assert.Nil(t, err)
+				defer stopWatcher(prov, ctx)
 
 				mc := make(chan *pb.Message)
 				defer close(mc)
@@ -2968,6 +3029,7 @@ func Test_Publish_ContextCancellation_ExitsPromptly(t *testing.T) {
 	defer cancel()
 	cc := &pb.ConnectionConfiguration{}
 	assert.Nil(t, prov.Connect(ctx, cc, false))
+	defer stopWatcher(prov, ctx)
 
 	// messageChannel is never closed and never has messages.  The only exit
 	// from the Publish select loop is ctx.Done() (post-fix) or an AMQP error
@@ -3033,6 +3095,7 @@ func Test_Publish_NotifyCloseChannelsAreBuffered(t *testing.T) {
 	defer cancel()
 	cc := &pb.ConnectionConfiguration{}
 	assert.Nil(t, prov.Connect(ctx, cc, false))
+	defer stopWatcher(prov, ctx)
 
 	messageChannel := make(chan *pb.Message)
 	errChan := make(chan *pb.Error, 1)
@@ -3136,6 +3199,7 @@ func Test_QueueSubscribe_NotifyCloseChannelsAreBuffered(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	assert.Nil(t, prov.Connect(ctx, cc, false))
+	defer stopWatcher(prov, ctx)
 
 	src := &pb.Source{
 		Name:    "queue",

--- a/internal/provider/connectors/amqp091/amqp091_test.go
+++ b/internal/provider/connectors/amqp091/amqp091_test.go
@@ -42,7 +42,7 @@ const testXMatchAny = "any"
 // package-level NewAmqpConn091 swap (read in connect()) or panic calling
 // IsClosed() on a stale mock from its 30s fallback branch. It is a no-op if the
 // connection was already disconnected.
-func stopWatcher(p provider.Provider, ctx context.Context) {
+func stopWatcher(ctx context.Context, p provider.Provider) {
 	prov, ok := p.(*amqp091provider)
 	if !ok {
 		return
@@ -202,7 +202,7 @@ func TestConnect(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 
 	assert.Nil(t, err)
 
@@ -233,7 +233,7 @@ func TestConnect_Error(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 
 	assert.NotNil(t, err)
 
@@ -256,7 +256,7 @@ func Test_Connect_NoClient(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.GetMessage(), "noclient")
@@ -289,7 +289,7 @@ func TestConnect_TLS_SkipVerify(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	cc.Tls = true
 	err := prov.Connect(ctx, cc, true)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 
 	assert.Nil(t, err)
 
@@ -324,7 +324,7 @@ func TestConnect_TLS_WithCert(t *testing.T) {
 	cc.Tls = true
 	cc.CaCertificate = []byte("asdf")
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 
 	assert.Nil(t, err)
 
@@ -357,7 +357,7 @@ func TestConnect_Stats(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	stats := prov.Stats()
@@ -393,7 +393,7 @@ func setupProviderWithSimpleConn(t *testing.T) (provider.Provider, context.Conte
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	cleanup := func() {
@@ -476,7 +476,7 @@ func Test_Ack_AckErr(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -541,7 +541,7 @@ func Test_Retry_NoMsg(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	msg := pb.Message{}
 	err = prov.Retry(ctx, &pb.Source{}, msg.GetUuid(), 10)
@@ -575,7 +575,7 @@ func Test_DeadLetter_NoMsg(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	msg := pb.Message{}
 	err = prov.DeadLetter(ctx, &pb.Source{}, msg.GetUuid())
@@ -646,7 +646,7 @@ func Test_Ack(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -738,7 +738,7 @@ func Test_Nack(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -828,7 +828,7 @@ func Test_Nack_NackErr(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -924,7 +924,7 @@ func Test_Retry(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	src := &pb.Source{Name: "queue", Address: &pb.Address{Name: "address"}}
@@ -1012,7 +1012,7 @@ func Test_RetryFailure(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	src := &pb.Source{Name: "queue", Address: &pb.Address{Name: "address"}}
@@ -1116,7 +1116,7 @@ func Test_RetryFailure_DeclareErrorsStillSuccess(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	opts := make(map[string]string)
@@ -1296,7 +1296,7 @@ func Test_DLQ(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	subjects := make([]string, 0)
@@ -1536,7 +1536,7 @@ func Test_Subscribe_Options(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -1647,7 +1647,7 @@ func Test_Subscribe_NoSubjectsNoFilters(t *testing.T) {
 	cc.AdminPort = int32(i) //nolint:gosec
 
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -1724,7 +1724,7 @@ func Test_Subscribe_UnsupportedOptions(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	src := &pb.Source{Address: &pb.Address{Name: "addressname"}, Options: options}
@@ -1766,7 +1766,7 @@ func Test_Disconnect(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	prov.Disconnect(ctx)
 
@@ -1814,7 +1814,7 @@ func Test_WaitForConnect(t *testing.T) {
 
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	errs <- newAmqp091Error("chanerr", 1) // simulate an error
 	time.Sleep(500 * time.Millisecond)
@@ -1873,7 +1873,7 @@ func Test_Publish(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	go func() {
@@ -1935,7 +1935,7 @@ func Test_Publish_Error(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	go func() {
@@ -2003,7 +2003,7 @@ func Test_PublishOne(t *testing.T) {
 
 		suberr := prov.PublishOne(ctx, msg)
 
-		stopWatcher(prov, ctx)
+		stopWatcher(ctx, prov)
 		NewAmqpConn091 = oldNewAmqpConn091
 
 		assert.Nil(t, suberr)
@@ -2054,7 +2054,7 @@ func Test_PublishOneFailed(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -2100,7 +2100,7 @@ func Test_PublishOneFailedNewChannel(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -2142,7 +2142,7 @@ func Test_PublishOneFailedConnClosed(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -2222,7 +2222,7 @@ func Test_Publish_ErrorDeclareExchange(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	go func() {
@@ -2328,7 +2328,7 @@ func Test_ClientExists(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	exists := prov.ClientExists("1234")
@@ -2361,7 +2361,7 @@ func Test_ClientExists_false(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	exists := prov.ClientExists("4321")
@@ -2716,7 +2716,7 @@ func Test_Subscribe_Queue_DeclareOnly(t *testing.T) {
 
 				err := prov.Connect(ctx, cc, false)
 				assert.Nil(t, err)
-				defer stopWatcher(prov, ctx)
+				defer stopWatcher(ctx, prov)
 
 				mc := make(chan *pb.Message)
 				defer close(mc)
@@ -3029,7 +3029,7 @@ func Test_Publish_ContextCancellation_ExitsPromptly(t *testing.T) {
 	defer cancel()
 	cc := &pb.ConnectionConfiguration{}
 	assert.Nil(t, prov.Connect(ctx, cc, false))
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 
 	// messageChannel is never closed and never has messages.  The only exit
 	// from the Publish select loop is ctx.Done() (post-fix) or an AMQP error
@@ -3095,7 +3095,7 @@ func Test_Publish_NotifyCloseChannelsAreBuffered(t *testing.T) {
 	defer cancel()
 	cc := &pb.ConnectionConfiguration{}
 	assert.Nil(t, prov.Connect(ctx, cc, false))
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 
 	messageChannel := make(chan *pb.Message)
 	errChan := make(chan *pb.Error, 1)
@@ -3199,7 +3199,7 @@ func Test_QueueSubscribe_NotifyCloseChannelsAreBuffered(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	assert.Nil(t, prov.Connect(ctx, cc, false))
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 
 	src := &pb.Source{
 		Name:    "queue",

--- a/internal/provider/connectors/amqp091/stream_test.go
+++ b/internal/provider/connectors/amqp091/stream_test.go
@@ -260,6 +260,7 @@ func Test_PublishStream(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	go func() {
@@ -332,6 +333,7 @@ func Test_PublishStreamWithConfirm(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	go func() {
@@ -391,6 +393,7 @@ func Test_PublishStreamFailed(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -443,6 +446,7 @@ func Test_PublishStreamFailedConn(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -496,6 +500,7 @@ func Test_PublishStreamNotConn(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -561,6 +566,7 @@ func Test_SubscribeStream(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -637,6 +643,7 @@ func Test_SubscribeStreamBadOpt(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	ctx, cancel := context.WithCancel(context.Background())
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -793,6 +800,7 @@ func Test_SubscribeStreamAutoDeleteOrExclusive(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	ctx, cancel := context.WithCancel(context.Background())
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -865,6 +873,7 @@ func Test_SubscribeStreamInvalidTTL(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	ctx, cancel := context.WithCancel(context.Background())
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -927,6 +936,7 @@ func Test_SubscribeStreamFailedConn(t *testing.T) {
 
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -989,6 +999,7 @@ func Test_SubscribeStreamNotConn(t *testing.T) {
 
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -1053,6 +1064,7 @@ func Test_SubscribeStreamFailedDeclare(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -1124,6 +1136,7 @@ func Test_StreamRetry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
+	defer stopWatcher(prov, ctx)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -1208,6 +1221,7 @@ func Test_Subscribe_Stream_DeclareOnly(t *testing.T) {
 				cc := &pb.ConnectionConfiguration{}
 				err := prov.Connect(ctx, cc, false)
 				assert.Nil(t, err)
+				defer stopWatcher(prov, ctx)
 
 				mc := make(chan *pb.Message)
 				defer close(mc)

--- a/internal/provider/connectors/amqp091/stream_test.go
+++ b/internal/provider/connectors/amqp091/stream_test.go
@@ -260,7 +260,7 @@ func Test_PublishStream(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	go func() {
@@ -333,7 +333,7 @@ func Test_PublishStreamWithConfirm(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	go func() {
@@ -393,7 +393,7 @@ func Test_PublishStreamFailed(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -446,7 +446,7 @@ func Test_PublishStreamFailedConn(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -500,7 +500,7 @@ func Test_PublishStreamNotConn(t *testing.T) {
 	ctx := context.Background()
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	suberr := prov.PublishOne(ctx, msg)
@@ -566,7 +566,7 @@ func Test_SubscribeStream(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -643,7 +643,7 @@ func Test_SubscribeStreamBadOpt(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	ctx, cancel := context.WithCancel(context.Background())
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -800,7 +800,7 @@ func Test_SubscribeStreamAutoDeleteOrExclusive(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	ctx, cancel := context.WithCancel(context.Background())
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -873,7 +873,7 @@ func Test_SubscribeStreamInvalidTTL(t *testing.T) {
 	cc := &pb.ConnectionConfiguration{}
 	ctx, cancel := context.WithCancel(context.Background())
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -936,7 +936,7 @@ func Test_SubscribeStreamFailedConn(t *testing.T) {
 
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -999,7 +999,7 @@ func Test_SubscribeStreamNotConn(t *testing.T) {
 
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -1064,7 +1064,7 @@ func Test_SubscribeStreamFailedDeclare(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 
 	mc := make(chan *pb.Message)
@@ -1136,7 +1136,7 @@ func Test_StreamRetry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cc := &pb.ConnectionConfiguration{}
 	err := prov.Connect(ctx, cc, false)
-	defer stopWatcher(prov, ctx)
+	defer stopWatcher(ctx, prov)
 	assert.Nil(t, err)
 	var msg *pb.Message
 
@@ -1221,7 +1221,7 @@ func Test_Subscribe_Stream_DeclareOnly(t *testing.T) {
 				cc := &pb.ConnectionConfiguration{}
 				err := prov.Connect(ctx, cc, false)
 				assert.Nil(t, err)
-				defer stopWatcher(prov, ctx)
+				defer stopWatcher(ctx, prov)
 
 				mc := make(chan *pb.Message)
 				defer close(mc)


### PR DESCRIPTION
Fixes #108

Add a `sync.WaitGroup` to `BrokerDetails` so the `connectionWatcher` goroutine started by `Connect` is joinable, plus a `stopWatcher` test helper deferred in every `Connect`-based test so a watcher can no longer outlive its test and race the `NewAmqpConn091` swap or panic on a stale mock.

Stacked on #102; retarget to `main` once it merges.
