### PR TITLE
test(server): cover Healthz notify path (MonitorHealthChan/notifyHealth)

### DIFF
--- a/internal/server/health_internal_test.go
+++ b/internal/server/health_internal_test.go
@@ -20,26 +20,19 @@ func clearHealthNotifiers() {
 	}
 }
 
-func TestNotifyHealthRegistersReceiver(t *testing.T) {
-	clearHealthNotifiers()
-	defer clearHealthNotifiers()
-
-	addr := "client-register"
-	rec := make(chan pb.HealthStatus_Code, 1)
-	notifyHealth(addr, rec)
-
-	got, ok := healthNotifiers.Get(addr)
-	assert.True(t, ok, "receiver should be registered for the client address")
-	assert.Equal(t, rec, got)
-}
-
-func TestNotifyHealthReplacesAndClosesPriorReceiver(t *testing.T) {
+func TestNotifyHealthRegistersAndReplacesReceiver(t *testing.T) {
 	clearHealthNotifiers()
 	defer clearHealthNotifiers()
 
 	addr := "client-replace"
+
 	first := make(chan pb.HealthStatus_Code, 1)
 	notifyHealth(addr, first)
+
+	// A single notifier is registered for the client address.
+	got, ok := healthNotifiers.Get(addr)
+	assert.True(t, ok, "receiver should be registered for the client address")
+	assert.Equal(t, first, got)
 
 	second := make(chan pb.HealthStatus_Code, 1)
 	notifyHealth(addr, second)
@@ -49,7 +42,7 @@ func TestNotifyHealthReplacesAndClosesPriorReceiver(t *testing.T) {
 	assert.False(t, open, "prior receiver channel should be closed on replacement")
 
 	// ...and leave only the new receiver registered.
-	got, ok := healthNotifiers.Get(addr)
+	got, ok = healthNotifiers.Get(addr)
 	assert.True(t, ok)
 	assert.Equal(t, second, got)
 }

--- a/internal/server/health_internal_test.go
+++ b/internal/server/health_internal_test.go
@@ -1,0 +1,87 @@
+// Copyright © 2026, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	pb "github.com/sassoftware/arke/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// clearHealthNotifiers empties the package-level notifier registry so each test
+// starts from a known state and MonitorHealthChan does not fan out to notifiers
+// left over from other tests.
+func clearHealthNotifiers() {
+	for _, addr := range healthNotifiers.GetList() {
+		healthNotifiers.Delete(addr)
+	}
+}
+
+func TestNotifyHealthRegistersReceiver(t *testing.T) {
+	clearHealthNotifiers()
+	defer clearHealthNotifiers()
+
+	addr := "client-register"
+	rec := make(chan pb.HealthStatus_Code, 1)
+	notifyHealth(addr, rec)
+
+	got, ok := healthNotifiers.Get(addr)
+	assert.True(t, ok, "receiver should be registered for the client address")
+	assert.Equal(t, rec, got)
+}
+
+func TestNotifyHealthReplacesAndClosesPriorReceiver(t *testing.T) {
+	clearHealthNotifiers()
+	defer clearHealthNotifiers()
+
+	addr := "client-replace"
+	first := make(chan pb.HealthStatus_Code, 1)
+	notifyHealth(addr, first)
+
+	second := make(chan pb.HealthStatus_Code, 1)
+	notifyHealth(addr, second)
+
+	// Registering a second notifier for the same client must close the prior one.
+	_, open := <-first
+	assert.False(t, open, "prior receiver channel should be closed on replacement")
+
+	// ...and leave only the new receiver registered.
+	got, ok := healthNotifiers.Get(addr)
+	assert.True(t, ok)
+	assert.Equal(t, second, got)
+}
+
+func TestMonitorHealthChanFansOutToNotifiers(t *testing.T) {
+	clearHealthNotifiers()
+	defer clearHealthNotifiers()
+
+	notifier := make(chan pb.HealthStatus_Code, 1)
+	notifyHealth("client-fanout", notifier)
+
+	receiver := make(chan pb.HealthStatus_Code)
+	done := make(chan struct{})
+	go func() {
+		MonitorHealthChan(receiver)
+		close(done)
+	}()
+
+	receiver <- pb.HealthStatus_GOAWAY
+
+	select {
+	case code := <-notifier:
+		assert.Equal(t, pb.HealthStatus_GOAWAY, code)
+	case <-time.After(time.Second):
+		t.Fatal("notifier did not receive the broadcast health code")
+	}
+
+	// Closing the source channel must end the monitor loop.
+	close(receiver)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("MonitorHealthChan did not exit after its receiver was closed")
+	}
+}

--- a/internal/server/health_internal_test.go
+++ b/internal/server/health_internal_test.go
@@ -58,8 +58,12 @@ func TestMonitorHealthChanFansOutToNotifiers(t *testing.T) {
 	clearHealthNotifiers()
 	defer clearHealthNotifiers()
 
-	notifier := make(chan pb.HealthStatus_Code, 1)
-	notifyHealth("client-fanout", notifier)
+	// Register multiple notifiers so the test exercises the actual fan-out loop
+	// over the registry, not just delivery to a single receiver.
+	first := make(chan pb.HealthStatus_Code, 1)
+	second := make(chan pb.HealthStatus_Code, 1)
+	notifyHealth("client-fanout-1", first)
+	notifyHealth("client-fanout-2", second)
 
 	receiver := make(chan pb.HealthStatus_Code)
 	done := make(chan struct{})
@@ -70,11 +74,19 @@ func TestMonitorHealthChanFansOutToNotifiers(t *testing.T) {
 
 	receiver <- pb.HealthStatus_GOAWAY
 
-	select {
-	case code := <-notifier:
-		assert.Equal(t, pb.HealthStatus_GOAWAY, code)
-	case <-time.After(time.Second):
-		t.Fatal("notifier did not receive the broadcast health code")
+	for _, tc := range []struct {
+		name     string
+		notifier chan pb.HealthStatus_Code
+	}{
+		{"first", first},
+		{"second", second},
+	} {
+		select {
+		case code := <-tc.notifier:
+			assert.Equal(t, pb.HealthStatus_GOAWAY, code, "%s notifier should receive the broadcast code", tc.name)
+		case <-time.After(time.Second):
+			t.Fatalf("%s notifier did not receive the broadcast health code", tc.name)
+		}
 	}
 
 	// Closing the source channel must end the monitor loop.


### PR DESCRIPTION
Fixes #110

Adds internal unit tests for the Healthz notify path: `notifyHealth` receiver registration/replacement and `MonitorHealthChan` fan-out + clean exit on channel close. Test-only, no production change.
