### PR TITLE
fix(ci): drop empty ignore list from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
         update-types:
           - minor
           - patch
-    ignore: []
   - package-ecosystem: gomod
     directory: "/api"
     schedule:


### PR DESCRIPTION
Fixes #122

Remove the bare `ignore: []` left on the first gomod entry, which failed Dependabot config validation on every PR.